### PR TITLE
Align VI scripts with new model implementation

### DIFF
--- a/VariationalInference/ancestral.py
+++ b/VariationalInference/ancestral.py
@@ -23,24 +23,24 @@ def generate_synthetic_data(n_samples, n_genes, n_programs, p_aux=1, seed=42):
     keys = random.split(key, 10)
     
     hyperparams = {
-        "c_prime": 2.0,
-        "d_prime": 2.0,
-        "c": 0.8,
-        "a_prime": 2.0,
-        "b_prime": 2.0,
-        "a": 0.8,
-        "tau": 2.0,
-        "sigma": 2.0,
+        "alpha_eta": 2.0,
+        "lambda_eta": 2.0,
+        "alpha_beta": 0.8,
+        "alpha_xi": 2.0,
+        "lambda_xi": 2.0,
+        "alpha_theta": 0.8,
+        "sigma2_v": 2.0,
+        "sigma2_gamma": 2.0,
         "d": n_programs
     }
 
-    eta_true = random.gamma(keys[0], hyperparams["c_prime"], shape=(n_genes,)) / hyperparams["d_prime"]
-    
-    beta_true = random.gamma(keys[1], hyperparams["c"], shape=(n_genes, n_programs)) / jnp.expand_dims(eta_true, axis=1)
-    
-    xi_true = random.gamma(keys[2], hyperparams["a_prime"], shape=(n_samples,)) / hyperparams["b_prime"]
-    
-    theta_true = random.gamma(keys[3], hyperparams["a"], shape=(n_samples, n_programs)) / jnp.expand_dims(xi_true, axis=1)
+    eta_true = random.gamma(keys[0], hyperparams["alpha_eta"], shape=(n_genes,)) / hyperparams["lambda_eta"]
+
+    beta_true = random.gamma(keys[1], hyperparams["alpha_beta"], shape=(n_genes, n_programs)) / jnp.expand_dims(eta_true, axis=1)
+
+    xi_true = random.gamma(keys[2], hyperparams["alpha_xi"], shape=(n_samples,)) / hyperparams["lambda_xi"]
+
+    theta_true = random.gamma(keys[3], hyperparams["alpha_theta"], shape=(n_samples, n_programs)) / jnp.expand_dims(xi_true, axis=1)
     
     gamma_true = jnp.zeros((1, p_aux))
     if p_aux > 0:

--- a/VariationalInference/debug_elbo.py
+++ b/VariationalInference/debug_elbo.py
@@ -99,14 +99,14 @@ def debug_elbo_calculation(x_data, y_data, x_aux, hyperparams, mask=None, max_it
             if len(x_aux.shape) == 1:
                 x_aux = x_aux.reshape(-1, 1)
 
-            c_prime = hyperparams['c_prime']
-            d_prime = hyperparams['d_prime']
-            c       = hyperparams['c']
-            a_prime = hyperparams['a_prime']
-            b_prime = hyperparams['b_prime']
-            a       = hyperparams['a']
-            tau     = hyperparams['tau']
-            sigma   = hyperparams['sigma']
+            alpha_eta = hyperparams['alpha_eta']
+            lambda_eta = hyperparams['lambda_eta']
+            alpha_beta = hyperparams['alpha_beta']
+            alpha_xi = hyperparams['alpha_xi']
+            lambda_xi = hyperparams['lambda_xi']
+            alpha_theta = hyperparams['alpha_theta']
+            sigma2_v = hyperparams['sigma2_v']
+            sigma2_gamma = hyperparams['sigma2_gamma']
 
             E_eta_flat = E_eta.flatten()
             E_xi_flat  = E_xi.flatten()
@@ -120,10 +120,10 @@ def debug_elbo_calculation(x_data, y_data, x_aux, hyperparams, mask=None, max_it
             
             # Prior distributions
             E_log_p_eta = jnp.sum(
-                c_prime * jnp.log(d_prime)
-                - jax.scipy.special.gammaln(c_prime)
-                + (c_prime - 1) * jnp.log(E_eta_flat + 1e-10)
-                - d_prime * E_eta_flat
+                alpha_eta * jnp.log(lambda_eta)
+                - jax.scipy.special.gammaln(alpha_eta)
+                + (alpha_eta - 1) * jnp.log(E_eta_flat + 1e-10)
+                - lambda_eta * E_eta_flat
             )
             
             E_eta_col = E_eta.reshape(-1, 1)
@@ -132,9 +132,9 @@ def debug_elbo_calculation(x_data, y_data, x_aux, hyperparams, mask=None, max_it
             else:
                 E_eta_broadcast = E_eta_col
             E_log_p_beta = jnp.sum(
-                c * jnp.log(E_eta_broadcast + 1e-10)
-                - jax.scipy.special.gammaln(c)
-                + (c - 1) * jnp.log(E_beta + 1e-10)
+                alpha_beta * jnp.log(E_eta_broadcast + 1e-10)
+                - jax.scipy.special.gammaln(alpha_beta)
+                + (alpha_beta - 1) * jnp.log(E_beta + 1e-10)
                 - E_eta_broadcast * E_beta
             )
             
@@ -144,10 +144,10 @@ def debug_elbo_calculation(x_data, y_data, x_aux, hyperparams, mask=None, max_it
             )
             
             E_log_p_xi = jnp.sum(
-                a_prime * jnp.log(b_prime)
-                - jax.scipy.special.gammaln(a_prime)
-                + (a_prime - 1) * jnp.log(E_xi_flat + 1e-10)
-                - b_prime * E_xi_flat
+                alpha_xi * jnp.log(lambda_xi)
+                - jax.scipy.special.gammaln(alpha_xi)
+                + (alpha_xi - 1) * jnp.log(E_xi_flat + 1e-10)
+                - lambda_xi * E_xi_flat
             )
             
             E_xi_col = E_xi.reshape(-1, 1)
@@ -156,9 +156,9 @@ def debug_elbo_calculation(x_data, y_data, x_aux, hyperparams, mask=None, max_it
             else:
                 E_xi_broadcast = E_xi_col
             E_log_p_theta = jnp.sum(
-                a * jnp.log(E_xi_broadcast + 1e-10)
-                - jax.scipy.special.gammaln(a)
-                + (a - 1) * jnp.log(E_theta + 1e-10)
+                alpha_theta * jnp.log(E_xi_broadcast + 1e-10)
+                - jax.scipy.special.gammaln(alpha_theta)
+                + (alpha_theta - 1) * jnp.log(E_theta + 1e-10)
                 - E_xi_broadcast * E_theta
             )
             
@@ -183,9 +183,9 @@ def debug_elbo_calculation(x_data, y_data, x_aux, hyperparams, mask=None, max_it
                 + (1 - y_data) * jnp.log(1 - probs + 1e-10)
             )
             
-            E_log_p_gamma = -0.5 * jnp.sum(E_gamma**2) / sigma**2
+            E_log_p_gamma = -0.5 * jnp.sum(E_gamma**2) / sigma2_gamma**2
             # Laplace prior on upsilon for sparsity
-            E_log_p_upsilon = -jnp.sum(jnp.abs(E_upsilon)) / tau - E_upsilon.size * jnp.log(2 * tau)
+            E_log_p_upsilon = -jnp.sum(jnp.abs(E_upsilon)) / sigma2_v - E_upsilon.size * jnp.log(2 * sigma2_v)
             
             # Variational distributions
             alpha_eta = q_params['alpha_eta']
@@ -463,11 +463,11 @@ def main():
     
     # Set hyperparameters
     hyperparams = {
-        "c_prime": 2.0,  "d_prime": 3.0,
-        "c":      0.6,
-        "a_prime":2.0,   "b_prime": 3.0,
-        "a":      0.6,
-        "tau":    4.0,   "sigma":   4.0,
+        "alpha_eta": 2.0,  "lambda_eta": 3.0,
+        "alpha_beta": 0.6,
+        "alpha_xi": 2.0,   "lambda_xi": 3.0,
+        "alpha_theta": 0.6,
+        "sigma2_v": 4.0,   "sigma2_gamma":   4.0,
         "d":      args.d
     }
     

--- a/VariationalInference/run_experiments.py
+++ b/VariationalInference/run_experiments.py
@@ -359,11 +359,11 @@ def run_combined_gp_and_pathway_experiment(dataset_name, adata, label_col, mask,
         print(f"Found cyto_seed_score in dataset with mean value: {np.mean(scores):.4f}")
 
     hyperparams = {
-        "c_prime": 2.0, "d_prime": 3.0,
-        "c":      0.6,
-        "a_prime": 2.0, "b_prime": 3.0,
-        "a":      0.6,
-        "tau":    1.0, "sigma":   1.0
+        "alpha_eta": 2.0, "lambda_eta": 3.0,
+        "alpha_beta": 0.6,
+        "alpha_xi": 2.0, "lambda_xi": 3.0,
+        "alpha_theta": 0.6,
+        "sigma2_v": 1.0, "sigma2_gamma": 1.0
     }
     
     n_pathways = mask.shape[1]
@@ -490,11 +490,11 @@ def run_pathway_initialized_experiment(dataset_name, adata, label_col, mask, pat
         print(f"Found cyto_seed_score in dataset with mean value: {np.mean(scores):.4f}")
 
     hyperparams = {
-        "c_prime": 2.0, "d_prime": 3.0,
-        "c":      0.6,
-        "a_prime": 2.0, "b_prime": 3.0,
-        "a":      0.6,
-        "tau":    1.0, "sigma":   1.0
+        "alpha_eta": 2.0, "lambda_eta": 3.0,
+        "alpha_beta": 0.6,
+        "alpha_xi": 2.0, "lambda_xi": 3.0,
+        "alpha_theta": 0.6,
+        "sigma2_v": 1.0, "sigma2_gamma": 1.0
     }
     
     n_pathways = mask.shape[1]
@@ -666,11 +666,11 @@ def main():
         
         # Set up hyperparams for EMTAB
         hyperparams_emtab = {
-            "c_prime": 2.0,  "d_prime": 3.0,
-            "c":      0.6,
-            "a_prime":2.0,   "b_prime": 3.0,
-            "a":      0.6,
-            "tau":    1.0,   "sigma":   1.0,
+            "alpha_eta": 2.0,  "lambda_eta": 3.0,
+            "alpha_beta": 0.6,
+            "alpha_xi": 2.0,   "lambda_xi": 3.0,
+            "alpha_theta": 0.6,
+            "sigma2_v": 1.0,   "sigma2_gamma": 1.0,
         }
         if args.mask:
             hyperparams_emtab["d"] = mask_array.shape[1]
@@ -757,11 +757,11 @@ def main():
             clear_memory()
         # Set up hyperparams for cyto/ap
         hyperparams_cyto = {
-            "c_prime": 2.0,  "d_prime": 3.0,
-            "c":      0.6,
-            "a_prime":2.0,   "b_prime": 3.0,
-            "a":      0.6,
-            "tau":    1.0,   "sigma":   1.0,
+            "alpha_eta": 2.0,  "lambda_eta": 3.0,
+            "alpha_beta": 0.6,
+            "alpha_xi": 2.0,   "lambda_xi": 3.0,
+            "alpha_theta": 0.6,
+            "sigma2_v": 1.0,   "sigma2_gamma":   1.0,
         }
         if args.mask:
             hyperparams_cyto["d"] = mask_array.shape[1]

--- a/VariationalInference/sample_vi_subset.py
+++ b/VariationalInference/sample_vi_subset.py
@@ -24,14 +24,14 @@ def run_subset_vi(n_cells=500, n_genes=500, max_iters=10, seed=0):
     var_names = list(subset.var_names)
 
     hyperparams = {
-        "c_prime": 2.0,
-        "d_prime": 3.0,
-        "c": 0.6,
-        "a_prime": 2.0,
-        "b_prime": 3.0,
-        "a": 0.6,
-        "tau": 1.0,
-        "sigma": 1.0,
+        "alpha_eta": 2.0,
+        "lambda_eta": 3.0,
+        "alpha_beta": 0.6,
+        "alpha_xi": 2.0,
+        "lambda_xi": 3.0,
+        "alpha_theta": 0.6,
+        "sigma2_v": 1.0,
+        "sigma2_gamma": 1.0,
         "d": 3,
     }
 

--- a/VariationalInference/synthetic_vi_test.py
+++ b/VariationalInference/synthetic_vi_test.py
@@ -9,20 +9,20 @@ def generate_synthetic_data(n_samples, n_genes, n_programs, p_aux=1, seed=0):
     key = random.PRNGKey(seed)
     keys = random.split(key, 10)
     hyperparams = {
-        "c_prime": 2.0,
-        "d_prime": 2.0,
-        "c": 0.8,
-        "a_prime": 2.0,
-        "b_prime": 2.0,
-        "a": 0.8,
-        "tau": 2.0,
-        "sigma": 2.0,
+        "alpha_eta": 2.0,
+        "lambda_eta": 2.0,
+        "alpha_beta": 0.8,
+        "alpha_xi": 2.0,
+        "lambda_xi": 2.0,
+        "alpha_theta": 0.8,
+        "sigma2_v": 2.0,
+        "sigma2_gamma": 2.0,
         "d": n_programs,
     }
-    eta_true = random.gamma(keys[0], hyperparams["c_prime"], shape=(n_genes,)) / hyperparams["d_prime"]
-    beta_true = random.gamma(keys[1], hyperparams["c"], shape=(n_genes, n_programs)) / jnp.expand_dims(eta_true, axis=1)
-    xi_true = random.gamma(keys[2], hyperparams["a_prime"], shape=(n_samples,)) / hyperparams["b_prime"]
-    theta_true = random.gamma(keys[3], hyperparams["a"], shape=(n_samples, n_programs)) / jnp.expand_dims(xi_true, axis=1)
+    eta_true = random.gamma(keys[0], hyperparams["alpha_eta"], shape=(n_genes,)) / hyperparams["lambda_eta"]
+    beta_true = random.gamma(keys[1], hyperparams["alpha_beta"], shape=(n_genes, n_programs)) / jnp.expand_dims(eta_true, axis=1)
+    xi_true = random.gamma(keys[2], hyperparams["alpha_xi"], shape=(n_samples,)) / hyperparams["lambda_xi"]
+    theta_true = random.gamma(keys[3], hyperparams["alpha_theta"], shape=(n_samples, n_programs)) / jnp.expand_dims(xi_true, axis=1)
     gamma_true = jnp.zeros((1, p_aux))
     upsilon_true = jnp.zeros((1, n_programs))
     rate = jnp.dot(theta_true, beta_true.T)


### PR DESCRIPTION
## Summary
- adapt helper scripts to use new `SupervisedPoissonFactorization`
- implement simplified `run_model_and_evaluate` compatible with new class
- rename hyperparameter dictionaries across scripts

## Testing
- `python -m py_compile VariationalInference/vi_model_complete.py VariationalInference/sample_vi_subset.py VariationalInference/synthetic_vi_test.py VariationalInference/ancestral.py VariationalInference/run_experiments.py VariationalInference/debug_elbo.py`
- `python - <<'PY'
from VariationalInference.vi_model_complete import run_model_and_evaluate, SupervisedPoissonFactorization
print('funcs loaded', callable(run_model_and_evaluate))
PY`
- `python - <<'PY'
import numpy as np
from VariationalInference.vi_model_complete import run_model_and_evaluate
X = np.random.poisson(1.0, (10,5))
X_aux = np.ones((10,1))
Y = np.random.randint(0,2,(10,1))
hyper = {"alpha_eta":1.0,"lambda_eta":1.0,"alpha_beta":1.0,"alpha_xi":1.0,"lambda_xi":1.0,"alpha_theta":1.0,"sigma2_v":1.0,"sigma2_gamma":1.0,"d":2}
res = run_model_and_evaluate(X,X_aux,Y, list(range(5)), hyper, seed=0, max_iters=2)
print('done',res['train_metrics']['accuracy'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_687430a4d07c83308b9d6e9cbcc724c4