### PR TITLE
Fix SVI minibatch updates

### DIFF
--- a/VariationalInference/svi.py
+++ b/VariationalInference/svi.py
@@ -45,18 +45,20 @@ def fit_svi(model, X, Y, X_aux, n_iter=100, batch_size=64, verbose=False):
         params.update(beta_update)
         expected = model.expected_values(params)
 
-        params.update(model.update_v_full(params, expected, Y_b, X_aux_b))
+        params.update(model.update_v_minibatch(params, expected, Y_b, X_aux_b, batch_idx, scale))
         expected = model.expected_values(params)
 
-        params.update(model.update_gamma_full(params, expected, Y_b, X_aux_b))
+        params.update(model.update_gamma_minibatch(params, expected, Y_b, X_aux_b, batch_idx, scale))
         expected = model.expected_values(params)
 
-        theta_update = model.update_theta(params, expected, z_b * scale, Y_b, X_aux_b)
+        theta_update = model.update_theta_minibatch(params, expected, z_b * scale, Y_b, X_aux_b, batch_idx)
         params["a_theta"] = params["a_theta"].at[batch_idx].set(theta_update["a_theta"])
         params["b_theta"] = params["b_theta"].at[batch_idx].set(theta_update["b_theta"])
         expected = model.expected_values(params)
 
-        params.update(model.update_zeta(params, expected, Y_b, X_aux_b))
+        params["zeta"] = params["zeta"].at[batch_idx].set(
+            model.update_zeta_minibatch(params, expected, Y_b, X_aux_b, batch_idx)["zeta"]
+        )
 
         if verbose and (it % 10 == 0):
             elbo = model.compute_elbo(X_b, Y_b, X_aux_b, params, z_b, return_components=False)


### PR DESCRIPTION
## Summary
- implement minibatch update functions for `v`, `gamma`, `theta`, and `zeta`
- use the new minibatch updates in `fit_svi`

## Testing
- `python - <<'EOF'
from svi import run_model_and_evaluate as run_svi
from synthetic_vi_test import generate_synthetic_data
import numpy as np

# run a small synthetic example
_ = run_svi(np.array(generate_synthetic_data(20,10,3)["x_data"]),
            np.ones((20,1)),
            np.ones((20,1)),
            [f'g{i}' for i in range(10)],
            generate_synthetic_data(20,10,3)["hyperparams"],
            seed=0, max_iters=1, batch_size=5)
EOF

------
https://chatgpt.com/codex/tasks/task_e_687d62ad48388330ac1a571b9796e318