### PR TITLE
Fix SVI minibatch ELBO

### DIFF
--- a/VariationalInference/svi.py
+++ b/VariationalInference/svi.py
@@ -61,7 +61,15 @@ def fit_svi(model, X, Y, X_aux, n_iter=100, batch_size=64, verbose=False):
         )
 
         if verbose and (it % 10 == 0):
-            elbo = model.compute_elbo(X_b, Y_b, X_aux_b, params, z_b, return_components=False)
+            elbo = model.compute_elbo(
+                X_b,
+                Y_b,
+                X_aux_b,
+                params,
+                z_b,
+                return_components=False,
+                batch_idx=batch_idx,
+            )
             print(f"SVI iter {it+1}, minibatch ELBO {float(elbo):.3f}")
 
     return params, model.expected_values(params)


### PR DESCRIPTION
## Summary
- allow minibatch indexing in `compute_elbo`
- call `compute_elbo` with `batch_idx` during SVI updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anndata')*

------
https://chatgpt.com/codex/tasks/task_e_687d66018980833097fcc6109dd88c3b